### PR TITLE
feat: #2 Member 회원가입 api 구현 

### DIFF
--- a/src/main/java/me/kycho/playchat/controller/MemberController.java
+++ b/src/main/java/me/kycho/playchat/controller/MemberController.java
@@ -1,0 +1,29 @@
+package me.kycho.playchat.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.kycho.playchat.controller.dto.JoinResultDto;
+import me.kycho.playchat.controller.dto.MemberDto;
+import me.kycho.playchat.domain.Member;
+import me.kycho.playchat.service.MemberService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping()
+    public ResponseEntity<JoinResultDto> join(@RequestBody MemberDto memberDto) {
+        // TODO : 예외 처리
+        Member joinedMember = memberService.join(memberDto.toEntity());
+        JoinResultDto result = JoinResultDto.from(joinedMember);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+}

--- a/src/main/java/me/kycho/playchat/controller/dto/JoinResultDto.java
+++ b/src/main/java/me/kycho/playchat/controller/dto/JoinResultDto.java
@@ -1,0 +1,17 @@
+package me.kycho.playchat.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import me.kycho.playchat.domain.Member;
+
+@Getter
+@AllArgsConstructor
+public class JoinResultDto {
+
+    private String email;
+    private String name;
+
+    public static JoinResultDto from(Member member) {
+        return new JoinResultDto(member.getEmail(), member.getName());
+    }
+}

--- a/src/main/java/me/kycho/playchat/controller/dto/MemberDto.java
+++ b/src/main/java/me/kycho/playchat/controller/dto/MemberDto.java
@@ -1,0 +1,28 @@
+package me.kycho.playchat.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.kycho.playchat.domain.Member;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberDto {
+
+    private String email;
+    private String password;
+    private String name;
+    private String imageUrl;
+
+    public Member toEntity() {
+        return Member.builder()
+            .email(email)
+            .password(password)
+            .name(name)
+            .imageUrl(imageUrl)
+            .build();
+    }
+}

--- a/src/main/java/me/kycho/playchat/domain/Member.java
+++ b/src/main/java/me/kycho/playchat/domain/Member.java
@@ -1,0 +1,39 @@
+package me.kycho.playchat.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    // TODO : 생성일, 수정일, 삭제일
+}

--- a/src/main/java/me/kycho/playchat/domain/Member.java
+++ b/src/main/java/me/kycho/playchat/domain/Member.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity

--- a/src/main/java/me/kycho/playchat/repository/MemberRepository.java
+++ b/src/main/java/me/kycho/playchat/repository/MemberRepository.java
@@ -1,8 +1,10 @@
 package me.kycho.playchat.repository;
 
+import java.util.Optional;
 import me.kycho.playchat.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/me/kycho/playchat/repository/MemberRepository.java
+++ b/src/main/java/me/kycho/playchat/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package me.kycho.playchat.repository;
+
+import me.kycho.playchat.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/me/kycho/playchat/service/MemberService.java
+++ b/src/main/java/me/kycho/playchat/service/MemberService.java
@@ -1,0 +1,29 @@
+package me.kycho.playchat.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import me.kycho.playchat.domain.Member;
+import me.kycho.playchat.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member join(Member member) {
+        validateDuplicateMember(member);
+        return memberRepository.save(member);
+    }
+
+    private void validateDuplicateMember(Member member) {
+        Optional<Member> findMember = memberRepository.findByEmail(member.getEmail());
+        if (findMember.isPresent()) {
+            throw new IllegalStateException("이미 존재하는 회원입니다.");
+        }
+    }
+}

--- a/src/test/java/me/kycho/playchat/controller/MemberControllerTest.java
+++ b/src/test/java/me/kycho/playchat/controller/MemberControllerTest.java
@@ -1,0 +1,47 @@
+package me.kycho.playchat.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.kycho.playchat.controller.dto.MemberDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MemberControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("정상 회원가입 테스트")
+    void joinTest() throws Exception {
+        String email = "member@email.com";
+        String name = "member";
+        MemberDto memberDto = new MemberDto(email, "password", name, "image_url");
+
+        mockMvc.perform(
+                post("/api/members")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(memberDto))
+            )
+            .andDo(print())
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("email").value(email))
+            .andExpect(jsonPath("name").value(name))
+        ;
+    }
+}

--- a/src/test/java/me/kycho/playchat/repository/MemberRepositoryTest.java
+++ b/src/test/java/me/kycho/playchat/repository/MemberRepositoryTest.java
@@ -45,11 +45,7 @@ class MemberRepositoryTest {
             .orElseThrow(NotFoundException::new);
 
         // then
-        assertThat(findMember.getId()).isGreaterThan(0);
-        assertThat(findMember.getEmail()).isEqualTo(email);
-        assertThat(findMember.getPassword()).isEqualTo(password);
-        assertThat(findMember.getName()).isEqualTo(name);
-        assertThat(findMember.getImageUrl()).isEqualTo(imageUrl);
+        assertThat(findMember).usingRecursiveComparison().isEqualTo(savedMember);
     }
 
     @DisplayName("member 저장시 누락된 정보 있을 경우 에러 발생")
@@ -103,7 +99,7 @@ class MemberRepositoryTest {
         String name = "member";
         String imageUrl = "image_url";
         Member newMember = createMember(email, password, name, imageUrl);
-        memberRepository.save(newMember);
+        Member savedMember = memberRepository.save(newMember);
 
         em.flush();
         em.clear();
@@ -113,11 +109,7 @@ class MemberRepositoryTest {
             .orElseThrow(NotFoundException::new);
 
         // then
-        assertThat(findMember.getId()).isGreaterThan(0);
-        assertThat(findMember.getEmail()).isEqualTo(email);
-        assertThat(findMember.getPassword()).isEqualTo(password);
-        assertThat(findMember.getName()).isEqualTo(name);
-        assertThat(findMember.getImageUrl()).isEqualTo(imageUrl);
+        assertThat(findMember).usingRecursiveComparison().isEqualTo(savedMember);
     }
 
 

--- a/src/test/java/me/kycho/playchat/repository/MemberRepositoryTest.java
+++ b/src/test/java/me/kycho/playchat/repository/MemberRepositoryTest.java
@@ -3,6 +3,9 @@ package me.kycho.playchat.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.persistence.EntityManager;
 import me.kycho.playchat.domain.Member;
 import org.junit.jupiter.api.DisplayName;
@@ -88,6 +91,36 @@ class MemberRepositoryTest {
         }, "email 값은 중복을 허용하지 않습니다.");
     }
 
+    @Test
+    @DisplayName("email로 Member 조회")
+    void findByEmailTest() throws NotFoundException {
+        // given
+        List<Member> members = createMembers(1);
+        memberRepository.saveAll(members);
+
+        String email = "member@email.com";
+        String password = "password";
+        String name = "member";
+        String imageUrl = "image_url";
+        Member newMember = createMember(email, password, name, imageUrl);
+        memberRepository.save(newMember);
+
+        em.flush();
+        em.clear();
+
+        // when
+        Member findMember = memberRepository.findByEmail(email)
+            .orElseThrow(NotFoundException::new);
+
+        // then
+        assertThat(findMember.getId()).isGreaterThan(0);
+        assertThat(findMember.getEmail()).isEqualTo(email);
+        assertThat(findMember.getPassword()).isEqualTo(password);
+        assertThat(findMember.getName()).isEqualTo(name);
+        assertThat(findMember.getImageUrl()).isEqualTo(imageUrl);
+    }
+
+
     private Member createMember(String email, String password, String name, String imageUrl) {
         return Member.builder()
             .email(email)
@@ -95,5 +128,16 @@ class MemberRepositoryTest {
             .name(name)
             .imageUrl(imageUrl)
             .build();
+    }
+
+    private List<Member> createMembers(int memberNum) {
+        return IntStream.rangeClosed(1, memberNum).mapToObj((idx) -> {
+            System.out.println("idx = " + idx);
+            String email = "member" + idx + "@email.com";
+            String password = "pass";
+            String name = "member" + idx;
+            String imageUrl = "image_url" + idx;
+            return createMember(email, password, name, imageUrl);
+        }).collect(Collectors.toList());
     }
 }

--- a/src/test/java/me/kycho/playchat/repository/MemberRepositoryTest.java
+++ b/src/test/java/me/kycho/playchat/repository/MemberRepositoryTest.java
@@ -1,0 +1,99 @@
+package me.kycho.playchat.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.persistence.EntityManager;
+import me.kycho.playchat.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
+
+@DataJpaTest
+class MemberRepositoryTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("member 저장 및 조회 테스트")
+    void saveTest() throws NotFoundException {
+        // given
+        String email = "member@email.com";
+        String password = "password";
+        String name = "member";
+        String imageUrl = "image_url";
+
+        // when
+        Member newMember = createMember(email, password, name, imageUrl);
+        Member savedMember = memberRepository.save(newMember);
+        em.flush();
+        em.clear();
+
+        Member findMember = memberRepository.findById(savedMember.getId())
+            .orElseThrow(NotFoundException::new);
+
+        // then
+        assertThat(findMember.getId()).isGreaterThan(0);
+        assertThat(findMember.getEmail()).isEqualTo(email);
+        assertThat(findMember.getPassword()).isEqualTo(password);
+        assertThat(findMember.getName()).isEqualTo(name);
+        assertThat(findMember.getImageUrl()).isEqualTo(imageUrl);
+    }
+
+    @DisplayName("member 저장시 누락된 정보 있을 경우 에러 발생")
+    @ParameterizedTest(name = "{index}: {0} 누락 테스트")
+    @CsvSource({
+        "email     ,                 , password, name, image_url",
+        "password  , member@email.com,         , name, image_url",
+        "name      , member@email.com, password,     , image_url",
+        "imageUrl  , member@email.com, password, name,          "
+    })
+    void saveErrorTest_insufficient_data(
+        String target, String email, String password, String name, String imageUrl) {
+
+        // given
+        Member member = createMember(email, password, name, imageUrl);
+
+        // when & then
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            memberRepository.save(member);
+        }, target + " 값은 필수 입니다.");
+    }
+
+    @Test
+    @DisplayName("member 저장시 중복된 email 에러 발생")
+    void savedErrorTest_duplicated_email() {
+        // given
+        String duplicatedEmail = "member@email.com";
+        Member member = createMember(duplicatedEmail, "password", "name", "image_url");
+        memberRepository.save(member);
+        em.flush();
+        em.clear();
+
+        // when & then
+        Member duplicatedEmailMember =
+            createMember(duplicatedEmail, "diff_password", "diff_name", "diff_image_url");
+
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            memberRepository.save(duplicatedEmailMember);
+        }, "email 값은 중복을 허용하지 않습니다.");
+    }
+
+    private Member createMember(String email, String password, String name, String imageUrl) {
+        return Member.builder()
+            .email(email)
+            .password(password)
+            .name(name)
+            .imageUrl(imageUrl)
+            .build();
+    }
+}

--- a/src/test/java/me/kycho/playchat/service/MemberServiceTest.java
+++ b/src/test/java/me/kycho/playchat/service/MemberServiceTest.java
@@ -1,0 +1,80 @@
+package me.kycho.playchat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+import me.kycho.playchat.domain.Member;
+import me.kycho.playchat.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @MockBean
+    MemberRepository memberRepository;
+
+    @Autowired
+    MemberService memberService;
+
+    @Test
+    @DisplayName("회원 가입 테스트")
+    void joinTest() {
+        // given
+        Member member = Member.builder()
+            .email("member@email.com")
+            .password("password")
+            .name("name")
+            .imageUrl("image_url")
+            .build();
+
+        Member savedMember = Member.builder()
+            .id(1L)
+            .email(member.getEmail())
+            .password(member.getPassword())
+            .name(member.getName())
+            .imageUrl(member.getImageUrl())
+            .build();
+        given(memberRepository.save(member)).willReturn(savedMember);
+
+        // when
+        Member joinResultMember = memberService.join(member);
+
+        // then
+        assertThat(joinResultMember).usingRecursiveComparison().isEqualTo(savedMember);
+    }
+
+    @Test
+    @DisplayName("회원 가입 시 중복된 email이면 에러발생")
+    void joinErrorTest_duplicated_email() {
+        // given
+        Member member = Member.builder()
+            .email("member@email.com")
+            .password("password")
+            .name("name")
+            .imageUrl("image_url")
+            .build();
+
+        Member savedMember = Member.builder()
+            .id(1L)
+            .email(member.getEmail())
+            .password(member.getPassword())
+            .name(member.getName())
+            .imageUrl(member.getImageUrl())
+            .build();
+
+        given(memberRepository.findByEmail(member.getEmail())).willReturn(Optional.of(savedMember));
+
+        // when & then
+        assertThrows(IllegalStateException.class, () -> {
+            memberService.join(member);
+        }, "기존에 가입된 email로 가입할 수 없습니다.");
+    }
+}


### PR DESCRIPTION
단순한(이미지 파일 업로드, 비밀번호 암호화, 잘못된 요청에대한 에러처리 제외한)  member 회원가입 api를 구현하였습니다. 

요청과 응답은 아래와 같습니다. 
### request
```
POST /api/members
{
  "email" : "member@email.com",     
  "password" : "password",              
  "name": "member",                         
  "imageUrl" : "image_url"    // 이미지 업로드로 변경될 예정
}
```
### response
```
{
  "email" : "member@email.com",
  "name" : "member"
}
```

close #2 
