### PR TITLE
feat: #3  ID/PW 기반의 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/me/kycho/playchat/config/SecurityConfig.java
+++ b/src/main/java/me/kycho/playchat/config/SecurityConfig.java
@@ -1,11 +1,19 @@
 package me.kycho.playchat.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -13,6 +21,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .csrf().disable()
             .authorizeRequests()
             .antMatchers("/api/members/join").permitAll()
+            .antMatchers("/api/authenticate").permitAll()
             .anyRequest().authenticated()
         ;
     }

--- a/src/main/java/me/kycho/playchat/config/SecurityConfig.java
+++ b/src/main/java/me/kycho/playchat/config/SecurityConfig.java
@@ -1,0 +1,19 @@
+package me.kycho.playchat.config;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+            .csrf().disable()
+            .authorizeRequests()
+            .antMatchers("/api/members/join").permitAll()
+            .anyRequest().authenticated()
+        ;
+    }
+}

--- a/src/main/java/me/kycho/playchat/controller/AuthController.java
+++ b/src/main/java/me/kycho/playchat/controller/AuthController.java
@@ -1,0 +1,36 @@
+package me.kycho.playchat.controller;
+
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.kycho.playchat.controller.dto.SignInRequestDto;
+import me.kycho.playchat.controller.dto.TokenDto;
+import me.kycho.playchat.jwt.JwtTokenProvider;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final JwtTokenProvider tokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    @PostMapping("/api/authenticate")
+    public ResponseEntity<TokenDto> authenticate(@Valid @RequestBody SignInRequestDto signInDto) {
+
+        Authentication authenticationToken =
+            new UsernamePasswordAuthenticationToken(signInDto.getEmail(), signInDto.getPassword());
+
+        Authentication authentication =
+            authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        String jwt = tokenProvider.createToken(authentication);
+
+        return ResponseEntity.ok(new TokenDto(jwt));
+    }
+}

--- a/src/main/java/me/kycho/playchat/controller/dto/SignInRequestDto.java
+++ b/src/main/java/me/kycho/playchat/controller/dto/SignInRequestDto.java
@@ -1,0 +1,22 @@
+package me.kycho.playchat.controller.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignInRequestDto {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/me/kycho/playchat/controller/dto/TokenDto.java
+++ b/src/main/java/me/kycho/playchat/controller/dto/TokenDto.java
@@ -1,0 +1,15 @@
+package me.kycho.playchat.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenDto {
+
+    private String token;
+}

--- a/src/main/java/me/kycho/playchat/domain/Member.java
+++ b/src/main/java/me/kycho/playchat/domain/Member.java
@@ -36,4 +36,8 @@ public class Member {
     private String imageUrl;
 
     // TODO : 생성일, 수정일, 삭제일
+
+    public void changePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/me/kycho/playchat/jwt/JwtTokenProvider.java
+++ b/src/main/java/me/kycho/playchat/jwt/JwtTokenProvider.java
@@ -1,0 +1,94 @@
+package me.kycho.playchat.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+
+    private final Key key;
+    private final long tokenValidityInMilliseconds;
+
+    public JwtTokenProvider(
+        @Value("${jwt.secret}") String secret,
+        @Value("${jwt.token-validity-in-seconds}") long tokenValidityInSeconds
+    ) {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+        this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
+    }
+
+    public String createToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + this.tokenValidityInMilliseconds);
+
+        return Jwts.builder()
+            .setSubject(authentication.getName())
+            .claim(AUTHORITIES_KEY, authorities)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .setExpiration(validity)
+            .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts
+            .parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+
+        Collection<? extends GrantedAuthority> authorities =
+            Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        User principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SignatureException ex) {
+            log.error("Invalid JWT signature");
+        } catch (MalformedJwtException ex) {
+            log.error("Invalid JWT token");
+        } catch (ExpiredJwtException ex) {
+            log.error("Expired JWT token");
+        } catch (UnsupportedJwtException ex) {
+            log.error("Unsupported JWT token");
+        } catch (IllegalArgumentException ex) {
+            log.error("JWT claims string is empty.");
+        }
+        return false;
+    }
+}

--- a/src/main/java/me/kycho/playchat/service/CustomUserDetailsService.java
+++ b/src/main/java/me/kycho/playchat/service/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package me.kycho.playchat.service;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import me.kycho.playchat.domain.Member;
+import me.kycho.playchat.repository.MemberRepository;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findByEmail(username)
+            .orElseThrow(() -> new UsernameNotFoundException("[" + username + "] 회원을 찾을 수 없습니다."));
+
+        List<GrantedAuthority> authorities = Collections.
+            singletonList(new SimpleGrantedAuthority("ROLE_MEMBER"));
+
+        return new User(member.getEmail(), member.getPassword(), authorities);
+    }
+}

--- a/src/main/java/me/kycho/playchat/service/MemberService.java
+++ b/src/main/java/me/kycho/playchat/service/MemberService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import me.kycho.playchat.domain.Member;
 import me.kycho.playchat.exception.DuplicatedEmailException;
 import me.kycho.playchat.repository.MemberRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,10 +15,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public Member join(Member member) {
         validateDuplicateMember(member);
+
+        String encodedPassword = passwordEncoder.encode(member.getPassword());
+        member.changePassword(encodedPassword);
+
         return memberRepository.save(member);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,9 @@ logging.level:
   #org.hibernate.type: trace
 
 file.dir: /Users/kycho/Desktop/upload/
+
+jwt:
+  header: Authorization
+  #echo 'secretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecret'|base64
+  secret: c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0Cg==
+  token-validity-in-seconds: 86400

--- a/src/test/java/me/kycho/playchat/controller/AuthControllerTest.java
+++ b/src/test/java/me/kycho/playchat/controller/AuthControllerTest.java
@@ -1,0 +1,69 @@
+package me.kycho.playchat.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.kycho.playchat.controller.dto.SignInRequestDto;
+import me.kycho.playchat.domain.Member;
+import me.kycho.playchat.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class AuthControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("인증 요청 테스트 정상")
+    void authenticate() throws Exception {
+
+        // given
+        String email = "kycho@naver.com";
+        String password = "password";
+
+        Member member = Member.builder()
+            .email(email)
+            .password(passwordEncoder.encode(password))
+            .name("kycho")
+            .imageUrl("image_url")
+            .build();
+        memberRepository.save(member);
+
+        SignInRequestDto signInRequestDto = new SignInRequestDto(email, password);
+
+        // when & then
+        mockMvc.perform(
+            post("/api/authenticate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signInRequestDto))
+        )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("token").exists())
+        ;
+    }
+}

--- a/src/test/java/me/kycho/playchat/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/me/kycho/playchat/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,68 @@
+package me.kycho.playchat.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+class JwtTokenProviderTest {
+
+    @Test
+    @DisplayName("JWT 토큰 생성 및 authentication 조회 테스트")
+    void createTokenTest_And_getAuthenticationTest() {
+        // given
+        String email = "kycho@naver.com";
+        List<GrantedAuthority> authorities = Stream.of("MEMBER", "ADMIN")
+            .map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+
+        Authentication authentication =
+            new UsernamePasswordAuthenticationToken(email, "", authorities);
+
+        JwtTokenProvider tokenProvider = new JwtTokenProvider(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            86400L);
+
+        // when
+        String token = tokenProvider.createToken(authentication);
+        Authentication result = tokenProvider.getAuthentication(token);
+
+        // then
+        assertThat(result.getName()).isEqualTo(email);
+        assertThat(result.getAuthorities()).isEqualTo(authorities);
+    }
+
+    @Test
+    @DisplayName("토큰 유효성 검사 테스트")
+    void validateTokenTest() {
+        // given
+        String email = "kycho@naver.com";
+        List<GrantedAuthority> authorities = Stream.of("MEMBER", "ADMIN")
+            .map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+
+        Authentication authentication =
+            new UsernamePasswordAuthenticationToken(email, "", authorities);
+
+        JwtTokenProvider tokenProvider = new JwtTokenProvider(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            86400L);
+        JwtTokenProvider tokenProviderNoTime = new JwtTokenProvider(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            0L);
+
+        // when
+        String token = tokenProvider.createToken(authentication);
+        String tokenNoTime = tokenProviderNoTime.createToken(authentication);
+
+        // then
+        assertThat(tokenProvider.validateToken(token)).isTrue();
+        assertThat(tokenProvider.validateToken(token + "a")).isFalse();
+        assertThat(tokenProvider.validateToken(tokenNoTime)).isFalse();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,3 +18,9 @@ logging.level:
   #org.hibernate.type: trace
 
 file.dir: /Users/kycho/Desktop/upload/
+
+jwt:
+  header: Authorization
+  #echo 'secretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecret'|base64
+  secret: c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0Cg==
+  token-validity-in-seconds: 86400


### PR DESCRIPTION
## ID/PW 기반의 로그인 기능 구현
회원가입시에 사용한 email, password를 사용하여 로그인(인증)할 수 있는 api를 구현하였다. 
응답으로는 jwt 토큰을 발급해준다. 
 
요청과 응답은 아래와 같다. 
### request
```
POST /api/authenticate
{
  "email" : "member@email.com",     
  "password" : "password"              
}
```
### response
```
http status : 200 OK

{
  "token" : "eyJhbGciOiJIUzUxM~~~~",
}
```

close #3 
