### PR TITLE
feat: #20 회원가입시  입력값 검증 강화 

### DIFF
--- a/src/main/java/me/kycho/playchat/controller/dto/SignUpRequestDto.java
+++ b/src/main/java/me/kycho/playchat/controller/dto/SignUpRequestDto.java
@@ -12,13 +12,14 @@ import me.kycho.playchat.domain.Member;
 import org.springframework.web.multipart.MultipartFile;
 
 @Builder
-@Getter @Setter
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class SignUpRequestDto {
 
-    @Email
-    @NotBlank
+    @Email(message = "이메일 형식이어야 합니다.")
+    @NotBlank(message = "이메일은 필수값입니다.")
     private String email;
 
     @NotBlank

--- a/src/main/java/me/kycho/playchat/controller/dto/SignUpRequestDto.java
+++ b/src/main/java/me/kycho/playchat/controller/dto/SignUpRequestDto.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +29,8 @@ public class SignUpRequestDto {
         message = "비밀번호는 영문자, 숫자, 특수기호($@!%*#?&)가 적어도 1개 이상씩 포함된 길이 8~16인 글자여야 합니다.")
     private String password;
 
-    @NotBlank
+    @NotBlank(message = "닉네임은 필수값입니다.")
+    @Size(min = 1, max = 50, message = "닉네임은 최대 50자까지 가능합니다.")
     private String nickname;
 
     @NotNull  // TODO : 좀더 확인해봐야함

--- a/src/main/java/me/kycho/playchat/controller/dto/SignUpRequestDto.java
+++ b/src/main/java/me/kycho/playchat/controller/dto/SignUpRequestDto.java
@@ -3,6 +3,7 @@ package me.kycho.playchat.controller.dto;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +23,9 @@ public class SignUpRequestDto {
     @NotBlank(message = "이메일은 필수값입니다.")
     private String email;
 
-    @NotBlank
+    @NotBlank(message = "비밀번호는 필수값입니다.")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[$@!%*#?&]).{8,16}",
+        message = "비밀번호는 영문자, 숫자, 특수기호($@!%*#?&)가 적어도 1개 이상씩 포함된 길이 8~16인 글자여야 합니다.")
     private String password;
 
     @NotBlank

--- a/src/test/java/me/kycho/playchat/controller/MemberControllerTest.java
+++ b/src/test/java/me/kycho/playchat/controller/MemberControllerTest.java
@@ -233,6 +233,41 @@ class MemberControllerTest {
         ;
     }
 
+
+    @DisplayName("회원가입 테스트 ERROR(잘못된 닉네임)")
+    @ParameterizedTest(name = "{index}: 잘못된 닉네임 : {0}")
+    @NullAndEmptySource
+    @ValueSource(strings = {"aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeef"})
+    void signUpErrorTest_wrongNickname(String wrongNickname) throws Exception {
+
+        // given
+        MockMultipartFile profileImage = new MockMultipartFile(
+            "profileImage", "imageForTest.png", MediaType.IMAGE_PNG_VALUE,
+            new FileInputStream("./src/test/resources/static/imageForTest.png")
+        );
+
+        given(fileStore.storeFile(profileImage)).willReturn("storeFileName");
+
+        // when & then
+        mockMvc.perform(
+                multipart("/api/members/sign-up")
+                    .file(profileImage)
+                    .param("email", "member@email.com")
+                    .param("nickname", wrongNickname)
+                    .param("password", "aaaaaaaa1!")
+                    .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                    .accept(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("status").value(400))
+            .andExpect(jsonPath("message").value("Binding Error."))
+            .andExpect(jsonPath("fieldErrors[0].field").value("nickname"))
+            .andExpect(jsonPath("fieldErrors[0].defaultMessage").exists())
+            .andExpect(jsonPath("fieldErrors[0].rejectedValue").value(wrongNickname))
+        ;
+    }
+
     static final class PartContentModifyingPreprocessor extends OperationPreprocessorAdapter {
 
         private final OperationRequestPartFactory partFactory = new OperationRequestPartFactory();


### PR DESCRIPTION
회원가입시 들어오는 값들에대한 검증을 강화하고 관련 테스트코드를 추가하였다. 

- **email** :   이메일 형식
- **password**: 8 ~ 16자,   영어,특수문자,숫자 각 1개이상 포함
- **nickname** : 1 ~ 50자

close #20 