### PR TITLE
feat: #21 회원의 프로필 이미지를 조회할수 있는 api 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -80,3 +80,29 @@ include::{snippets}/member-signup/response-fields.adoc[]
 include::{snippets}/member-signup/curl-request.adoc[]
 ===== Response
 include::{snippets}/member-signup/http-response.adoc[]
+
+
+
+[[resources_members_profileimage]]
+=== Profile Image
+회원 프로필 이미지 조회에 사용될 api
+
+[[resources_members_profileimage_request]]
+==== Request
+===== Request HTTP Messages
+include::{snippets}/member-profileimage/http-request.adoc[]
+
+===== Request Header
+include::{snippets}/member-profileimage/request-headers.adoc[]
+
+[[resources_members_profileimage_response]]
+==== Response
+===== Response Body
+include::{snippets}/member-profileimage/response-body.adoc[]
+
+[[resources_members_profileimage_sample]]
+==== Sample
+===== Reqeust
+include::{snippets}/member-profileimage/curl-request.adoc[]
+===== Response
+include::{snippets}/member-profileimage/http-response.adoc[]

--- a/src/main/java/me/kycho/playchat/config/SecurityConfig.java
+++ b/src/main/java/me/kycho/playchat/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
             .antMatchers("/api/members/sign-up").permitAll()
             .antMatchers("/api/auth/sign-in").permitAll()
+            .antMatchers("/api/members/profile-image/**").permitAll()  // TODO: remove
             .anyRequest().authenticated()
             .and()
             .addFilterBefore(new JwtAuthenticationFilter(tokenProvider),

--- a/src/main/java/me/kycho/playchat/config/SecurityConfig.java
+++ b/src/main/java/me/kycho/playchat/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import me.kycho.playchat.security.CustomAuthenticationEntryPoint;
 import me.kycho.playchat.security.jwt.JwtAuthenticationFilter;
 import me.kycho.playchat.security.jwt.JwtTokenProvider;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -31,7 +30,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         web.
             ignoring()
             .antMatchers("/docs/index.html")
-            .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
         ;
     }
 
@@ -48,7 +46,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
             .antMatchers("/api/members/sign-up").permitAll()
             .antMatchers("/api/auth/sign-in").permitAll()
-            .antMatchers("/api/members/profile-image/**").permitAll()  // TODO: remove
             .anyRequest().authenticated()
             .and()
             .addFilterBefore(new JwtAuthenticationFilter(tokenProvider),

--- a/src/main/java/me/kycho/playchat/controller/MemberController.java
+++ b/src/main/java/me/kycho/playchat/controller/MemberController.java
@@ -1,7 +1,6 @@
 package me.kycho.playchat.controller;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import javax.validation.Valid;
 import me.kycho.playchat.common.FileStore;
 import me.kycho.playchat.controller.dto.SignUpRequestDto;
@@ -62,12 +61,14 @@ public class MemberController {
 
     @GetMapping("/profile-image/{filename}")
     public ResponseEntity<Resource> downloadImage(@PathVariable String filename)
-        throws MalformedURLException {
+        throws IOException {
 
         UrlResource urlResource = new UrlResource("file:" + fileStore.getFullPath(filename));
-
-        return ResponseEntity.ok()
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.IMAGE_PNG_VALUE)
-            .body(urlResource);
+        if (urlResource.exists()) {
+            return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.IMAGE_PNG_VALUE)
+                .body(urlResource);
+        }
+        return ResponseEntity.notFound().build();
     }
 }

--- a/src/main/java/me/kycho/playchat/controller/MemberController.java
+++ b/src/main/java/me/kycho/playchat/controller/MemberController.java
@@ -1,6 +1,7 @@
 package me.kycho.playchat.controller;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import javax.validation.Valid;
 import me.kycho.playchat.common.FileStore;
 import me.kycho.playchat.controller.dto.SignUpRequestDto;
@@ -8,9 +9,15 @@ import me.kycho.playchat.controller.dto.SignUpResponseDto;
 import me.kycho.playchat.domain.Member;
 import me.kycho.playchat.service.MemberService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,7 +50,7 @@ public class MemberController {
         if (storedFileName == null) {
             profileImageUrl += "/images/default-profile.png";
         } else {
-            profileImageUrl += "/members/profile-image/" + storedFileName;
+            profileImageUrl += "/api/members/profile-image/" + storedFileName;
         }
 
         signUpRequestDto.setProfileImageUrl(profileImageUrl);
@@ -51,5 +58,16 @@ public class MemberController {
         Member signedUpMember = memberService.signUp(signUpRequestDto.toMemberEntity());
         SignUpResponseDto response = SignUpResponseDto.from(signedUpMember);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/profile-image/{filename}")
+    public ResponseEntity<Resource> downloadImage(@PathVariable String filename)
+        throws MalformedURLException {
+
+        UrlResource urlResource = new UrlResource("file:" + fileStore.getFullPath(filename));
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.IMAGE_PNG_VALUE)
+            .body(urlResource);
     }
 }

--- a/src/test/java/me/kycho/playchat/controller/MemberControllerTest.java
+++ b/src/test/java/me/kycho/playchat/controller/MemberControllerTest.java
@@ -294,6 +294,15 @@ class MemberControllerTest {
         uploadedFile.delete();
     }
 
+    @Test
+    @DisplayName("프로필 이미지 조회 ERROR(존재하지 않는 이미지)")
+    void downloadImageTest_notFound() throws Exception {
+
+        // when & then
+        mockMvc.perform(get("/api/members/profile-image/noFile.png"))
+            .andExpect(status().isNotFound());
+    }
+
     static final class PartContentModifyingPreprocessor extends OperationPreprocessorAdapter {
 
         private final OperationRequestPartFactory partFactory = new OperationRequestPartFactory();

--- a/src/test/java/me/kycho/playchat/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/me/kycho/playchat/security/jwt/JwtTokenProviderTest.java
@@ -19,7 +19,7 @@ class JwtTokenProviderTest {
     void createTokenTest_And_getAuthenticationTest() {
         // given
         String email = "kycho@naver.com";
-        List<GrantedAuthority> authorities = Stream.of("MEMBER", "ADMIN")
+        List<GrantedAuthority> authorities = Stream.of("ROLE_MEMBER", "ROLE_ADMIN")
             .map(SimpleGrantedAuthority::new).collect(Collectors.toList());
 
         Authentication authentication =
@@ -43,7 +43,7 @@ class JwtTokenProviderTest {
     void validateTokenTest() {
         // given
         String email = "kycho@naver.com";
-        List<GrantedAuthority> authorities = Stream.of("MEMBER", "ADMIN")
+        List<GrantedAuthority> authorities = Stream.of("ROLE_MEMBER", "ROLE_ADMIN")
             .map(SimpleGrantedAuthority::new).collect(Collectors.toList());
 
         Authentication authentication =


### PR DESCRIPTION
회원의 프로필 이미지를 조회할수 있는 api를 구현함 

아래와 같이 요청을 보내면된다. 
```
GET /api/members/profile-image/{profileImageFileName} HTTP/1.1  <---- 파일명을 명시한다. 
Authorization: Bearer XXXXXXX.YYYYYYYYYY.ZZZZZZ                 <---- 인증된 사용자만 볼수 있음
Host: localhost:8080
```

해당 url은 회원정보를 조회할때  회원정보에 포함할 예정이다. 
그리고 추후 파일업로드를 aws s3로 변경할 예정이다.  이때 api가 사라지거나 변경될수 있다.

close #21 